### PR TITLE
Fixes #11 issue (error when minrecords = 0)

### DIFF
--- a/classes/sync.php
+++ b/classes/sync.php
@@ -101,13 +101,13 @@ class tool_cohortdatabase_sync {
         $hasenoughrecords = false;
         $count = 0;
         $minrecords = $this->config->minrecords;
-        if (isset($minrecords) && ($minrecords !== false)) {
+        if (!empty($minrecords)) {
             $sql = "SELECT count(*) FROM $cohorttable";
             if ($rs = $extdb->Execute($sql)) {
                 if (!$rs->EOF) {
                     while ($fields = $rs->FetchRow()) {
                         $count = array_pop($fields);
-                        if ($count > $minrecords) {
+                        if ($count >= $minrecords) {
                             $hasenoughrecords = true;
                         }
                     }

--- a/classes/sync.php
+++ b/classes/sync.php
@@ -101,7 +101,7 @@ class tool_cohortdatabase_sync {
         $hasenoughrecords = false;
         $count = 0;
         $minrecords = $this->config->minrecords;
-        if (!empty($minrecords)) {
+        if (isset($minrecords) && ($minrecords !== false)) {
             $sql = "SELECT count(*) FROM $cohorttable";
             if ($rs = $extdb->Execute($sql)) {
                 if (!$rs->EOF) {


### PR DESCRIPTION
To fix issue #11 without losing the ability to check wheither `$minrecords` is false or not set.